### PR TITLE
fix: call wait on Kill

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.4: QmQtAm9iMWkV98JWotgfUQ3RRx7ZhxVDMZFnzEzmFwnKnU
+1.3.0: QmTD9SdvPDfzdQrBq4iSD3LDDaM3dKHtvvuGbqzMGUHkat

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   "license": "",
   "name": "iptb",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.4"
+  "version": "1.3.0"
 }
 


### PR DESCRIPTION
We need to call wait() on the process to fully kill it, without this it becomes a zombie and Kill() never exits.