### PR TITLE
Fix: Connect fails when nodes aren't online.

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -619,13 +619,13 @@ func ConnectNodes(from, to IpfsNode, timeout string) error {
 
 		if err == nil {
 			stump.Log("connection success!")
-			break
+			return nil
 		}
 		stump.Log("dial attempt to %s failed: %s", addr, err)
 		time.Sleep(time.Second)
 	}
 
-	return nil
+	return errors.New("no dialable addresses")
 }
 
 func orderishAddresses(addrs []string) {


### PR DESCRIPTION
Previously, an `ipfs connect <i> <j>` wouldn't return an error if `<i>` and `<j>` were offline. Now it does. To make this happen, `util`'s API now has a function `CheckNodesOnline()` that checks whether every `IpfsNode` in a slice is online.

Fixes https://github.com/ipfs/iptb/issues/51.