### PR TITLE
Add stat collection to IPTB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.so
 iptb
+.vscode
+topologies/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 iptb
 .vscode
 topologies/*
+deb.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ libp2p networks easy!
 ### Example
 
 ```
-$ iptb auto -count 5 >/dev/null
+$ iptb auto -count 5 -type <plugin_name> 
 
 $ iptb start
 
@@ -26,7 +26,7 @@ $ iptb shell 4
 $ ipfs cat QmNqugRcYjwh9pEQUK7MLuxvLjxDNZL1DH8PJJgWtQXxuF
 hey!
 ```
-
+Available plugins now: Local IPFS node (plugin_name: localipfs), Docker IPFS node (plugin_name: dockeripfs)
 ### Usage
 ```
 NAME:

--- a/commands/auto.go
+++ b/commands/auto.go
@@ -50,6 +50,7 @@ $ iptb auto           -count 5 -type <type>
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagEncoding := c.GlobalString("encoding")
 		flagType := c.String("type")
 		flagStart := c.Bool("start")
 		flagCount := c.Int("count")
@@ -88,7 +89,7 @@ $ iptb auto           -count 5 -type <type>
 			return err
 		}
 
-		if err := buildReport(results, "text"); err != nil {
+		if err := buildReport(results, flagEncoding); err != nil {
 			return err
 		}
 
@@ -102,7 +103,7 @@ $ iptb auto           -count 5 -type <type>
 				return err
 			}
 
-			if err := buildReport(results, "text"); err != nil {
+			if err := buildReport(results, flagEncoding); err != nil {
 				return err
 			}
 		}

--- a/commands/auto.go
+++ b/commands/auto.go
@@ -46,10 +46,6 @@ $ iptb auto           -count 5 -type <type>
 			Name:  "start",
 			Usage: "starts nodes immediately",
 		},
-		cli.BoolFlag{
-			Name:  "stats",
-			Usage: "Output statistics on the command execution",
-		},
 	},
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
@@ -58,7 +54,6 @@ $ iptb auto           -count 5 -type <type>
 		flagStart := c.Bool("start")
 		flagCount := c.Int("count")
 		flagForce := c.Bool("force")
-		flagStats := c.Bool("stats")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		if err := testbed.AlreadyInitCheck(tb.Dir(), flagForce); err != nil {
@@ -93,7 +88,7 @@ $ iptb auto           -count 5 -type <type>
 			return err
 		}
 
-		if err := buildReport(results, "Initialize Nodes", flagStats); err != nil {
+		if err := buildReport(results, "text"); err != nil {
 			return err
 		}
 
@@ -107,7 +102,7 @@ $ iptb auto           -count 5 -type <type>
 				return err
 			}
 
-			if err := buildReport(results, "Start nodes", flagStats); err != nil {
+			if err := buildReport(results, "text"); err != nil {
 				return err
 			}
 		}

--- a/commands/auto.go
+++ b/commands/auto.go
@@ -56,7 +56,6 @@ $ iptb auto           -count 5 -type <type>
 		flagForce := c.Bool("force")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
-
 		if err := testbed.AlreadyInitCheck(tb.Dir(), flagForce); err != nil {
 			return err
 		}

--- a/commands/auto.go
+++ b/commands/auto.go
@@ -46,6 +46,10 @@ $ iptb auto           -count 5 -type <type>
 			Name:  "start",
 			Usage: "starts nodes immediately",
 		},
+		cli.BoolFlag{
+			Name:  "stats",
+			Usage: "Output statistics on the command execution",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
@@ -54,6 +58,7 @@ $ iptb auto           -count 5 -type <type>
 		flagStart := c.Bool("start")
 		flagCount := c.Int("count")
 		flagForce := c.Bool("force")
+		flagStats := c.Bool("stats")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		if err := testbed.AlreadyInitCheck(tb.Dir(), flagForce); err != nil {
@@ -88,7 +93,7 @@ $ iptb auto           -count 5 -type <type>
 			return err
 		}
 
-		if err := buildReport(results); err != nil {
+		if err := buildReport(results, "Initialize Nodes", flagStats); err != nil {
 			return err
 		}
 
@@ -102,7 +107,7 @@ $ iptb auto           -count 5 -type <type>
 				return err
 			}
 
-			if err := buildReport(results); err != nil {
+			if err := buildReport(results, "Start nodes", flagStats); err != nil {
 				return err
 			}
 		}

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -1,9 +1,13 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"path"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -12,6 +16,7 @@ import (
 	"github.com/ipfs/iptb/testbed"
 )
 
+// TODO:Add explanation in the description for topology flag
 var ConnectCmd = cli.Command{
 	Category:  "CORE",
 	Name:      "connect",
@@ -47,20 +52,46 @@ INPUT         EXPANDED
 			Usage: "timeout on the command",
 			Value: "30s",
 		},
+		cli.StringFlag{
+			Name:  "topology",
+			Usage: "specify a network topology file",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
 		flagTimeout := c.String("timeout")
+		flagTopology := c.String("topology")
 
 		timeout, err := time.ParseDuration(flagTimeout)
 		if err != nil {
 			return err
 		}
-
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
-		args := c.Args()
 
+		// Case Topoloogy is specified
+		if len(flagTopology) != 0 {
+			nodes, err := tb.Nodes()
+			if err != nil {
+				return err
+			}
+			topologyGraph, err := parseTopology(flagRoot, len(nodes))
+			if err != nil {
+				return err
+			}
+			for _, connectionRow := range topologyGraph {
+				from := connectionRow[0]
+				to := connectionRow[1:]
+				err = connectNodes(tb, []int{from}, to, timeout)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		// Case range is specified
+		args := c.Args()
 		switch c.NArg() {
 		case 0:
 			nodes, err := tb.Nodes()
@@ -122,4 +153,70 @@ func connectNodes(tb testbed.BasicTestbed, from, to []int, timeout time.Duration
 	}
 
 	return buildReport(results)
+}
+
+func parseTopology(fileDir string, numberOfNodes int) ([][]int, error) {
+
+	// Scan Input file Line by Line //
+	inFile, err := os.Open(fileDir)
+	defer inFile.Close()
+	if err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(inFile)
+	scanner.Split(bufio.ScanLines)
+
+	// Store number of line to produce meaningful errors
+	lineNumber := 1
+	// Topology graph implemented as an Adjacency Matrix DS
+	// This intermediate variable it could be terminated to increase peformance
+	// This would decrease code readability.
+	var topology [][]int
+
+	for scanner.Scan() {
+		var destinations []string
+		var lineTokenized []string
+		line := scanner.Text()
+		// Check if the line is a comment or empty and skip it//
+		if len(line) == 0 || line[0] == '#' {
+			lineNumber++
+			continue
+		} else {
+			lineTokenized = strings.Split(line, ":")
+			// Check if the format is correct
+			if len(lineTokenized) == 1 {
+				return nil, errors.New("Line " + strconv.Itoa(lineNumber) + " does not follow the correct format")
+			}
+			destinations = strings.Split(lineTokenized[1], ",")
+		}
+		// Declare the topology in that line, the first element is the origin
+		var topologyLine []int
+		// Parse origin in the line
+		origin, err := strconv.Atoi(lineTokenized[0])
+		// Check if it can be casted to integer
+		if err != nil {
+			return nil, errors.New("Line: " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
+		}
+		// Check if the node is out of range
+		if origin >= numberOfNodes {
+			return nil, errors.New("Node origin in line: " + strconv.Itoa(lineNumber) + " out of range")
+		}
+		topologyLine = append(topologyLine, origin)
+		for _, destination := range destinations {
+			// Check if it can be casted to integer
+			target, err := strconv.Atoi(destination)
+			if err != nil {
+				return nil, errors.New("Check line: " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
+			}
+			// Check if the node is out of range
+			if target >= numberOfNodes {
+				return nil, errors.New("Node target in line: " + strconv.Itoa(lineNumber) + " out of range")
+			}
+			// Append destination to graph
+			topologyLine = append(topologyLine, target)
+		}
+		lineNumber++
+		topology = append(topology, topologyLine)
+	}
+	return topology, nil
 }

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -1,13 +1,9 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os"
 	"path"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -16,7 +12,6 @@ import (
 	"github.com/ipfs/iptb/testbed"
 )
 
-// TODO:Add explanation in the description for topology flag
 var ConnectCmd = cli.Command{
 	Category:  "CORE",
 	Name:      "connect",
@@ -28,17 +23,12 @@ The connect command allows for connecting sets of nodes together.
 Every node listed in the first set, will try to connect to every node
 listed in the second set.
 
-There are four variants of the command. It can accept no arugments,
-a single argument, two arguments or a file. The no argument and single argument
-expands out to the two argument usage. The file argument, parses the file and exapnds it
-to the two argument usage. The file should have the following format:
-- Node Origin:Connection 1 Connection 2 .... Connection n e.g. 0:1,2,3,4
-- Lines starting with # are ignored (comment line), empty lines are also ignored
-
+There are three variants of the command. It can accept no arugments,
+a single argument, two arguments. The no argument and single argument
+expands out to the two argument usage
 $ iptb connect             => iptb connect [0-C] [0-C]
 $ iptb connect [n-m]       => iptb connect [n-m] [n-m]
 $ iptb connect [n-m] [i-k]
-$ iptb connect -topology /directory/topology.txt
 
 Sets of nodes can be expressed in the following ways
 
@@ -56,43 +46,17 @@ INPUT         EXPANDED
 			Usage: "timeout on the command",
 			Value: "30s",
 		},
-		cli.StringFlag{
-			Name:  "topology",
-			Usage: "specify a network topology file",
-		},
 	},
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
 		flagTimeout := c.String("timeout")
-		flagTopology := c.String("topology")
 
 		timeout, err := time.ParseDuration(flagTimeout)
 		if err != nil {
 			return err
 		}
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
-
-		// Case Topoloogy is specified
-		if len(flagTopology) != 0 {
-			nodes, err := tb.Nodes()
-			if err != nil {
-				return err
-			}
-			topologyGraph, err := parseTopology(flagTopology, len(nodes))
-			if err != nil {
-				return err
-			}
-			for _, connectionRow := range topologyGraph {
-				from := connectionRow[0]
-				to := connectionRow[1:]
-				err = connectNodes(tb, []int{from}, to, timeout)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}
 
 		// Case range is specified
 		args := c.Args()
@@ -156,71 +120,5 @@ func connectNodes(tb testbed.BasicTestbed, from, to []int, timeout time.Duration
 		}
 	}
 
-	return buildReport(results, "", false)
-}
-
-func parseTopology(fileDir string, numberOfNodes int) ([][]int, error) {
-
-	// Scan Input file Line by Line //
-	inFile, err := os.Open(fileDir)
-	defer inFile.Close()
-	if err != nil {
-		return nil, err
-	}
-	scanner := bufio.NewScanner(inFile)
-	scanner.Split(bufio.ScanLines)
-
-	// Store number of line to produce meaningful errors
-	lineNumber := 1
-	// Topology graph implemented as an Adjacency Matrix DS
-	// This intermediate variable it could be terminated to increase peformance
-	// This would decrease code readability.
-	var topology [][]int
-
-	for scanner.Scan() {
-		var destinations []string
-		var lineTokenized []string
-		line := scanner.Text()
-		// Check if the line is a comment or empty and skip it//
-		if len(line) == 0 || line[0] == '#' {
-			lineNumber++
-			continue
-		} else {
-			lineTokenized = strings.Split(line, ":")
-			// Check if the format is correct
-			if len(lineTokenized) == 1 {
-				return nil, errors.New("Line " + strconv.Itoa(lineNumber) + " does not follow the correct format")
-			}
-			destinations = strings.Split(lineTokenized[1], ",")
-		}
-		// Declare the topology in that line, the first element is the origin
-		var topologyLine []int
-		// Parse origin in the line
-		origin, err := strconv.Atoi(lineTokenized[0])
-		// Check if it can be casted to integer
-		if err != nil {
-			return nil, errors.New("Line " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
-		}
-		// Check if the node is out of range
-		if origin >= numberOfNodes {
-			return nil, errors.New("Origin node in line " + strconv.Itoa(lineNumber) + " out of range")
-		}
-		topologyLine = append(topologyLine, origin)
-		for _, destination := range destinations {
-			// Check if it can be casted to integer
-			target, err := strconv.Atoi(destination)
-			if err != nil {
-				return nil, errors.New("Check line " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
-			}
-			// Check if the node is out of range
-			if target >= numberOfNodes {
-				return nil, errors.New("Target node in line " + strconv.Itoa(lineNumber) + " out of range")
-			}
-			// Append destination to graph
-			topologyLine = append(topologyLine, target)
-		}
-		lineNumber++
-		topology = append(topology, topologyLine)
-	}
-	return topology, nil
+	return buildReport(results, "text")
 }

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -28,13 +28,17 @@ The connect command allows for connecting sets of nodes together.
 Every node listed in the first set, will try to connect to every node
 listed in the second set.
 
-There are three variants of the command. It can accept no arugments,
-a single argument, or two arguments. The no argument and single argument
-expands out to the two argument usage.
+There are four variants of the command. It can accept no arugments,
+a single argument, two arguments or a file. The no argument and single argument
+expands out to the two argument usage. The file argument, parses the file and exapnds it
+to the two argument usage. The file should have the following format:
+- Node Origin:Connection 1 Connection 2 .... Connection n e.g. 0:1,2,3,4
+- Lines starting with # are ignored (comment line), empty lines are also ignored
 
 $ iptb connect             => iptb connect [0-C] [0-C]
 $ iptb connect [n-m]       => iptb connect [n-m] [n-m]
 $ iptb connect [n-m] [i-k]
+$ iptb connect -topology /directory/topology.txt
 
 Sets of nodes can be expressed in the following ways
 
@@ -75,7 +79,7 @@ INPUT         EXPANDED
 			if err != nil {
 				return err
 			}
-			topologyGraph, err := parseTopology(flagRoot, len(nodes))
+			topologyGraph, err := parseTopology(flagTopology, len(nodes))
 			if err != nil {
 				return err
 			}
@@ -195,22 +199,22 @@ func parseTopology(fileDir string, numberOfNodes int) ([][]int, error) {
 		origin, err := strconv.Atoi(lineTokenized[0])
 		// Check if it can be casted to integer
 		if err != nil {
-			return nil, errors.New("Line: " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
+			return nil, errors.New("Line " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
 		}
 		// Check if the node is out of range
 		if origin >= numberOfNodes {
-			return nil, errors.New("Node origin in line: " + strconv.Itoa(lineNumber) + " out of range")
+			return nil, errors.New("Origin node in line " + strconv.Itoa(lineNumber) + " out of range")
 		}
 		topologyLine = append(topologyLine, origin)
 		for _, destination := range destinations {
 			// Check if it can be casted to integer
 			target, err := strconv.Atoi(destination)
 			if err != nil {
-				return nil, errors.New("Check line: " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
+				return nil, errors.New("Check line " + strconv.Itoa(lineNumber) + " of connection graph, could not be parsed")
 			}
 			// Check if the node is out of range
 			if target >= numberOfNodes {
-				return nil, errors.New("Node target in line: " + strconv.Itoa(lineNumber) + " out of range")
+				return nil, errors.New("Target node in line " + strconv.Itoa(lineNumber) + " out of range")
 			}
 			// Append destination to graph
 			topologyLine = append(topologyLine, target)

--- a/commands/connect.go
+++ b/commands/connect.go
@@ -156,7 +156,7 @@ func connectNodes(tb testbed.BasicTestbed, from, to []int, timeout time.Duration
 		}
 	}
 
-	return buildReport(results)
+	return buildReport(results, "", false)
 }
 
 func parseTopology(fileDir string, numberOfNodes int) ([][]int, error) {

--- a/commands/init.go
+++ b/commands/init.go
@@ -21,6 +21,10 @@ var InitCmd = cli.Command{
 			Name:   "terminator",
 			Hidden: true,
 		},
+		cli.BoolFlag{
+			Name:  "stats",
+			Usage: "Output statistics on the command execution",
+		},
 	},
 	Before: func(c *cli.Context) error {
 		if present := isTerminatorPresent(c); present {
@@ -32,6 +36,7 @@ var InitCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagStats := c.Bool("stats")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -59,6 +64,6 @@ var InitCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, "Initialize Nodes", flagStats)
 	},
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -32,6 +32,7 @@ var InitCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagEncoding := c.GlobalString("encoding")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -59,6 +60,6 @@ var InitCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "text")
+		return buildReport(results, flagEncoding)
 	},
 }

--- a/commands/init.go
+++ b/commands/init.go
@@ -21,10 +21,6 @@ var InitCmd = cli.Command{
 			Name:   "terminator",
 			Hidden: true,
 		},
-		cli.BoolFlag{
-			Name:  "stats",
-			Usage: "Output statistics on the command execution",
-		},
 	},
 	Before: func(c *cli.Context) error {
 		if present := isTerminatorPresent(c); present {
@@ -36,7 +32,6 @@ var InitCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
-		flagStats := c.Bool("stats")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -64,6 +59,6 @@ var InitCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "Initialize Nodes", flagStats)
+		return buildReport(results, "text")
 	},
 }

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -84,7 +84,7 @@ var LogsCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, "", false)
 	},
 }
 

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -84,7 +84,7 @@ var LogsCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "", false)
+		return buildReport(results, "text")
 	},
 }
 

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -31,6 +31,7 @@ var LogsCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagEncoding := c.GlobalString("encoding")
 		flagErr := c.BoolT("err")
 		flagOut := c.BoolT("out")
 
@@ -84,7 +85,7 @@ var LogsCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "text")
+		return buildReport(results, flagEncoding)
 	},
 }
 

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -68,6 +68,6 @@ var RestartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, "", false)
 	},
 }

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -36,6 +36,7 @@ var RestartCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagEncoding := c.GlobalString("encoding")
 		flagWait := c.Bool("wait")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
@@ -68,6 +69,6 @@ var RestartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "text")
+		return buildReport(results, flagEncoding)
 	},
 }

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -68,6 +68,6 @@ var RestartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "", false)
+		return buildReport(results, "text")
 	},
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strings"
 
 	cli "github.com/urfave/cli"
 
@@ -21,6 +22,10 @@ var RunCmd = cli.Command{
 			Name:   "terminator",
 			Hidden: true,
 		},
+		cli.BoolFlag{
+			Name:  "stats",
+			Usage: "Output statistics on the command execution",
+		},
 	},
 	Before: func(c *cli.Context) error {
 		if present := isTerminatorPresent(c); present {
@@ -32,6 +37,7 @@ var RunCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagStats := c.Bool("stats")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -59,6 +65,6 @@ var RunCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, strings.Join(args[:], " "), flagStats)
 	},
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -22,9 +22,10 @@ var RunCmd = cli.Command{
 			Name:   "terminator",
 			Hidden: true,
 		},
-		cli.BoolFlag{
-			Name:  "stats",
-			Usage: "Output statistics on the command execution",
+		cli.StringFlag{
+			Name:  "encoding",
+			Usage: "Specify the output format, current options JSON and text",
+			Value: "text",
 		},
 	},
 	Before: func(c *cli.Context) error {
@@ -37,8 +38,19 @@ var RunCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
-		flagStats := c.Bool("stats")
+		flagFormat := c.String("encoding")
+		// Compare everything to lower to make it case insentive
+		flagFormatLwr := strings.ToLower(flagFormat)
 
+		// Parse output format
+		switch flagFormatLwr {
+		case "text":
+			// input is correct
+		case "json":
+			// input is correct
+		default:
+			NewUsageError("the output encoding provided is not parsable")
+		}
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
 		if err != nil {
@@ -65,6 +77,6 @@ var RunCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, strings.Join(args[:], " "), flagStats)
+		return buildReport(results, flagFormatLwr)
 	},
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"strings"
 
 	cli "github.com/urfave/cli"
 
@@ -22,35 +21,18 @@ var RunCmd = cli.Command{
 			Name:   "terminator",
 			Hidden: true,
 		},
-		cli.StringFlag{
-			Name:  "encoding",
-			Usage: "Specify the output format, current options JSON and text",
-			Value: "text",
-		},
 	},
 	Before: func(c *cli.Context) error {
 		if present := isTerminatorPresent(c); present {
 			return c.Set("terminator", "true")
 		}
-
 		return nil
 	},
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
-		flagFormat := c.String("encoding")
-		// Compare everything to lower to make it case insentive
-		flagFormatLwr := strings.ToLower(flagFormat)
+		flagEncoding := c.GlobalString("encoding")
 
-		// Parse output format
-		switch flagFormatLwr {
-		case "text":
-			// input is correct
-		case "json":
-			// input is correct
-		default:
-			NewUsageError("the output encoding provided is not parsable")
-		}
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
 		if err != nil {
@@ -77,6 +59,6 @@ var RunCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, flagFormatLwr)
+		return buildReport(results, flagEncoding)
 	},
 }

--- a/commands/start.go
+++ b/commands/start.go
@@ -64,6 +64,6 @@ var StartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, "", false)
 	},
 }

--- a/commands/start.go
+++ b/commands/start.go
@@ -64,6 +64,6 @@ var StartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "", false)
+		return buildReport(results, "text")
 	},
 }

--- a/commands/start.go
+++ b/commands/start.go
@@ -36,6 +36,7 @@ var StartCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagEncoding := c.GlobalString("encoding")
 		flagWait := c.Bool("wait")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
@@ -64,6 +65,6 @@ var StartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "text")
+		return buildReport(results, flagEncoding)
 	},
 }

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -46,6 +46,6 @@ var StopCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, "", false)
 	},
 }

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -19,6 +19,7 @@ var StopCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagEncoding := c.GlobalString("encoding")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -46,6 +47,6 @@ var StopCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "text")
+		return buildReport(results, flagEncoding)
 	},
 }

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -46,6 +46,6 @@ var StopCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results, "", false)
+		return buildReport(results, "text")
 	},
 }

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -123,10 +123,10 @@ func expandDashRange(s string) ([]int, error) {
 }
 
 type Result struct {
-	Node        int
-	Output      testbedi.Output
-	Error       error
-	TimeElapsed float64
+	Node    int
+	Output  testbedi.Output
+	Error   error
+	Elapsed float64
 }
 
 type outputFunc func(testbedi.Core) (testbedi.Output, error)
@@ -151,10 +151,10 @@ func mapWithOutput(list []int, nodes []testbedi.Core, fn outputFunc) ([]Result, 
 			defer lk.Unlock()
 
 			results[i] = Result{
-				Node:        n,
-				Output:      out,
-				Error:       errors.Wrapf(err, "node[%d]", n),
-				TimeElapsed: elapsed.Seconds(),
+				Node:    n,
+				Output:  out,
+				Error:   errors.Wrapf(err, "node[%d]", n),
+				Elapsed: elapsed.Seconds(),
 			}
 		}(i, n, nodes[n])
 	}
@@ -190,7 +190,7 @@ func buildReport(results []Result, encoding string) error {
 
 		if rs.Output != nil {
 			if encoding == "text" {
-				fmt.Printf("node[%d] exit %d Elapsed %.4fs \n", rs.Node, rs.Output.ExitCode(), rs.TimeElapsed)
+				fmt.Printf("node[%d] exit %d Elapsed %.4fs \n", rs.Node, rs.Output.ExitCode(), rs.Elapsed)
 				if rs.Output.Error() != nil {
 					fmt.Printf("%s", rs.Output.Error())
 				}

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -1,12 +1,15 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	cli "github.com/urfave/cli"
@@ -121,9 +124,10 @@ func expandDashRange(s string) ([]int, error) {
 }
 
 type Result struct {
-	Node   int
-	Output testbedi.Output
-	Error  error
+	Node        int
+	Output      testbedi.Output
+	Error       error
+	TimeElapsed float64
 }
 
 type outputFunc func(testbedi.Core) (testbedi.Output, error)
@@ -141,15 +145,17 @@ func mapWithOutput(list []int, nodes []testbedi.Core, fn outputFunc) ([]Result, 
 		wg.Add(1)
 		go func(i, n int, node testbedi.Core) {
 			defer wg.Done()
+			start := time.Now()
 			out, err := fn(node)
-
+			elapsed := time.Since(start)
 			lk.Lock()
 			defer lk.Unlock()
 
 			results[i] = Result{
-				Node:   n,
-				Output: out,
-				Error:  errors.Wrapf(err, "node[%d]", n),
+				Node:        n,
+				Output:      out,
+				Error:       errors.Wrapf(err, "node[%d]", n),
+				TimeElapsed: elapsed.Seconds(),
 			}
 		}(i, n, nodes[n])
 	}
@@ -175,7 +181,7 @@ func validRange(list []int, total int) error {
 	return nil
 }
 
-func buildReport(results []Result) error {
+func buildReport(results []Result, command string, statsFlag bool) error {
 	var errs []error
 
 	for _, rs := range results {
@@ -198,10 +204,63 @@ func buildReport(results []Result) error {
 		}
 
 	}
+	if statsFlag {
+		stats, err := buildStats(results)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			statsJSON, _ := json.Marshal(stats)
+			fmt.Printf("Executed command < %s > on %d node(s) \nTime Statistics %s \n", command, len(results), string(statsJSON))
+		}
+	}
 
 	if len(errs) != 0 {
 		return cli.NewMultiError(errs...)
 	}
 
 	return nil
+}
+
+type Stats struct {
+	Mean      float64
+	Std       float64
+	Max       float64
+	Quartile3 float64
+	Median    float64
+	Quartile1 float64
+	Min       float64
+}
+
+func buildStats(results []Result) (Stats, error) {
+	if len(results) == 0 {
+		return Stats{}, errors.New("Results are empty")
+	}
+	sum := 0.
+	sumSquarred := 0.
+	min := results[0].TimeElapsed
+	max := results[0].TimeElapsed
+	for _, rs := range results {
+		sum += rs.TimeElapsed
+		sumSquarred += rs.TimeElapsed * rs.TimeElapsed
+		if rs.TimeElapsed < min {
+			min = rs.TimeElapsed
+		}
+		if rs.TimeElapsed > max {
+			max = rs.TimeElapsed
+		}
+	}
+
+	mean := sum / float64(len(results))
+	variance := sumSquarred/float64(len(results)) - mean*mean
+
+	return Stats{
+		Mean:      mean,
+		Std:       math.Sqrt(variance),
+		Max:       max,
+		Quartile3: 0.,
+		Median:    0.,
+		Quartile1: 0.,
+		Min:       min,
+	}, nil
+
 }

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -204,6 +204,7 @@ func buildReport(results []Result, encoding string) error {
 				if rs.Output.Error() != nil {
 					fmt.Printf("%s", rs.Output.Error())
 				}
+				fmt.Println()
 				io.Copy(os.Stdout, rs.Output.Stdout())
 				io.Copy(os.Stdout, rs.Output.Stderr())
 			} else {
@@ -220,7 +221,7 @@ func buildReport(results []Result, encoding string) error {
 				}
 				pluginErr := string(pluginErrB)
 				// JSONify the plugin output
-				rsJSON, _ := json.Marshal(output{
+				rsJSON, err := json.Marshal(output{
 					Node:         rs.Node,
 					ExitCode:     rs.Output.ExitCode(),
 					Error:        rs.Output.Error(),
@@ -228,11 +229,18 @@ func buildReport(results []Result, encoding string) error {
 					PluginStderr: pluginErr,
 					Elapsed:      rs.Elapsed.Seconds(),
 				})
+
+				if err != nil {
+					errs = append(errs, err)
+				}
 				fmt.Printf("%s\n", rsJSON)
 			}
-			fmt.Println()
 		}
 
+	}
+	// Add an empty line between the commands if the encoding is not human readable
+	if encoding != "text" {
+		fmt.Println()
 	}
 	if len(errs) != 0 {
 		return cli.NewMultiError(errs...)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 )
 
 func loadPlugins(dir string) error {
+
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		return nil
 	}
@@ -24,6 +25,7 @@ func loadPlugins(dir string) error {
 	}
 
 	for _, f := range plugs {
+
 		plg, err := testbed.LoadPlugin(path.Join(dir, f.Name()))
 
 		if err != nil {
@@ -80,7 +82,6 @@ func main() {
 		}
 
 		c.Set("IPTB_ROOT", flagRoot)
-
 		return loadPlugins(path.Join(flagRoot, "plugins"))
 	}
 	app.Commands = []cli.Command{

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	cli "github.com/urfave/cli"
 
@@ -61,6 +62,11 @@ func main() {
 			EnvVar: "IPTB_ROOT",
 			Hidden: true,
 		},
+		cli.StringFlag{
+			Name:  "encoding",
+			Usage: "Specify the output format, current options JSON and text",
+			Value: "text",
+		},
 	}
 	app.Before = func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
@@ -80,6 +86,22 @@ func main() {
 				return err
 			}
 		}
+
+		// Parse encoding
+		flagFormat := c.GlobalString("encoding")
+		// Compare everything to lower to make it case insentive
+		flagFormatLwr := strings.ToLower(flagFormat)
+
+		// Parse output format
+		switch flagFormatLwr {
+		case "text":
+			// input is correct
+		case "json":
+			// input is correct
+		default:
+			return fmt.Errorf("the output encoding specified is not supported")
+		}
+		c.Set("encoding", flagFormatLwr)
 
 		c.Set("IPTB_ROOT", flagRoot)
 		return loadPlugins(path.Join(flagRoot, "plugins"))

--- a/testbed/spec.go
+++ b/testbed/spec.go
@@ -118,7 +118,6 @@ func loadPluginAttr(pl *plugin.Plugin, plg *IptbPlugin) (bool, error) {
 
 func loadPlugin(path string) (*IptbPlugin, error) {
 	pl, err := plugin.Open(path)
-
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Hey y'all,

Thanks for the project it helped me a lot!

As discussed in IPFS issue board [IPFS Performance #5226](https://github.com/ipfs/go-ipfs/issues/5226), I made some changes to the IPTB framework to generate measure the performance of IPFS and generate performance graphs. In detail I added the following functions in the framework:
- iptb make-topology: This creates a connection graph between the nodes (e.g. star topology, barbell topology). In the topology files empty lines and lines starting with # are disregarded. For non empty line the syntax is `origin:connection 1, connection 2 ...` where origin and connections are specified with their node ID.
- iptb dist -hash: The simulation here distributes a single file from node 0 to every other node in the network. Then it calculates the average time required to download the file, the standard deviation of the time, the maximum time, the minimum time, the duplicate blocks. The results are saved in a generated file called results.json. 

I also added a Python3 script to plot the results that adds an additional optional dependency in the project, Matplotlib. 

Finally I created a readme file, simulation.md, that explains the logic of the simulation. I also added there the response of @whyrusleeping  to the issue [Simulate bad network #50](https://github.com/ipfs/iptb/issues/50) so people would know that there is support for bad network.

I would appreciate your feedback and any improvements suggestions :) 