### PR TITLE
Plugin for jsipfs and ipfs in browser

### DIFF
--- a/plugins/ipfs/Makefile
+++ b/plugins/ipfs/Makefile
@@ -1,4 +1,4 @@
-all: ipfslocal ipfsdocker
+all: ipfslocal ipfsdocker ipfsbrowser
 
 deps:
 	gx install
@@ -15,4 +15,10 @@ ipfsdocker: deps
 	gx-go uw
 CLEAN += dockeripfs.so
 
-.PHONY: all ipfslocal ipfsdocker
+ipfsbrowser:
+	gx-go rw
+	(cd browser; go build -buildmode=plugin -o ../../browseripfs.so)
+	gx-go uw
+CLEAN += browseripfs.so
+
+.PHONY: all ipfslocal ipfsdocker ipfsbrowser

--- a/plugins/ipfs/util.go
+++ b/plugins/ipfs/util.go
@@ -210,8 +210,12 @@ func SwarmAddrs(l testbedi.Core) ([]string, error) {
 
 	var maddrs []string
 	for _, straddr := range straddrs {
-		fstraddr := fmt.Sprintf("%s/ipfs/%s", straddr, pcid)
-		maddrs = append(maddrs, fstraddr)
+		if !strings.Contains(straddr, pcid) {
+			fstraddr := fmt.Sprintf("%s/ipfs/%s", straddr, pcid)
+			maddrs = append(maddrs, fstraddr)
+		} else {
+			maddrs = append(maddrs, straddr)
+		}
 	}
 
 	return maddrs, nil


### PR DESCRIPTION
This PR adds support for jsipfs in both node and the browser.

The node jsipfs support was added by making a small changing to the localipfs plugin which enables it to take an attribute that defines the `ipfs` binary to use.

```shell
$ iptb testbed create -count 3 -type localipfs -force -attr binary,$(which jsipfs)
```

To support browsers a new plugin was built. The plugin is bundle with a nodejs script which runs an instance of the jsipfs api with an ipfs core interface proxy via ipfs-postmsg-proxy over websockets to the browser.

```
[ipfs-cli] <= http => [jsipfs-api => client(postmsg-proxy)] <= websocket => [server(postmsg-proxy) => ipfs-core]
```

```
$ iptb testbed create -count 3 -type browseripfs -force -attr source,/path/to/bundle.js
```

 - `source` defines a location on disk where the browser jsipfs bundle is located

Example script of running go-ipfs, js-ipfs and browser-ipfs

https://gist.github.com/travisperson/df370a47797d1ae801508914cd053b26