### PR TITLE
Input file with list of commands to run async on nodes

### DIFF
--- a/commands/run.go
+++ b/commands/run.go
@@ -70,6 +70,9 @@ var RunCmd = cli.Command{
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {
 			tokens := strings.Fields(scanner.Text())
+			if strings.HasPrefix(tokens[0], "#") {
+				continue
+			}
 			args = append(args, tokens)
 		}
 

--- a/commands/run.go
+++ b/commands/run.go
@@ -49,31 +49,27 @@ var RunCmd = cli.Command{
 		}
 
 		var args [][]string
-		var terminatorPresent []bool
+		var terminatorPresent bool
 		if c.IsSet("stdin") {
+			terminatorPresent = false
 			scanner := bufio.NewScanner(os.Stdin)
 			for scanner.Scan() {
 				tokens := strings.Fields(scanner.Text())
-				term := tokens[0] == "--"
-				if term {
-					tokens = tokens[1:]
-				}
-				terminatorPresent = append(terminatorPresent, term)
 				args = append(args, tokens)
 			}
 		} else {
+			terminatorPresent = c.IsSet("terminator")
 			cArgsStr := make([]string, c.NArg())
 			for i, arg := range c.Args() {
 				cArgsStr[i] = arg
 			}
 			args = append(args, cArgsStr)
-			terminatorPresent = append(terminatorPresent, c.IsSet("terminator"))
 		}
 
 		ranges := make([][]int, len(args))
 		runCmds := make([]outputFunc, len(args))
 		for i, cmd := range args {
-			nodeRange, tokens := parseCommand(cmd, terminatorPresent[i])
+			nodeRange, tokens := parseCommand(cmd, terminatorPresent)
 			if nodeRange == "" {
 				nodeRange = fmt.Sprintf("[0-%d]", len(nodes)-1)
 			}

--- a/commands/run.go
+++ b/commands/run.go
@@ -20,8 +20,42 @@ import (
 var RunCmd = cli.Command{
 	Category:  "CORE",
 	Name:      "run",
-	Usage:     "run command on specified nodes (or all)",
+	Usage:     "concurrently run command(s) on specified nodes (or all)",
 	ArgsUsage: "[nodes] -- <command...>",
+	Description: `
+Commands may also be passed in via stdin or a pipe, e.g. the command
+
+$ iptb run 0 -- echo "Running on node 0"
+
+can be equivalently written as
+
+$ iptb run <<CMD
+    0 -- echo "Running on node 0"
+  CMD
+
+or
+
+$ echo '0 -- echo "Running on node 0"' | iptb run
+
+All lines starting with '#' will be ignored, which allows for comments:
+
+$ iptb run <<CMD
+    # print ipfs peers
+    0 -- ipfs swarm peers
+  CMD
+
+Multiple commands may also be passed via stdin/pipe:
+
+$ iptb run <<CMDS
+    0     -- echo "Running on node 0"
+    [0,1] -- echo "Running on nodes 0 and 1"
+          -- echo "Running on all nodes"
+  CMDS
+
+Note that any single call to ` + "`iptb run`" + ` runs *all* commands concurrently. So,
+in the above example, there is no guarantee as to the order in which the lines
+are printed.
+`,
 	Flags: []cli.Flag{
 		cli.BoolFlag{
 			Name:   "terminator",

--- a/commands/run.go
+++ b/commands/run.go
@@ -34,6 +34,13 @@ var RunCmd = cli.Command{
 	},
 	Before: func(c *cli.Context) error {
 		if c.NArg() == 0 {
+			finfo, err := os.Stdin.Stat()
+			if err != nil {
+				return err
+			}
+			if finfo.Size() == 0 && finfo.Mode()&os.ModeNamedPipe == 0 {
+				return fmt.Errorf("error: no command input and stdin is empty")
+			}
 			return c.Set("stdin", "true")
 		}
 		if present := isTerminatorPresent(c); present {
@@ -53,15 +60,6 @@ var RunCmd = cli.Command{
 
 		var reader io.Reader
 		if c.IsSet("stdin") {
-			finfo, err := os.Stdin.Stat()
-			if err != nil {
-				return err
-			}
-			if finfo.Size() == 0 && finfo.Mode()&os.ModeNamedPipe == 0 {
-				cli.ShowCommandHelp(c, "run")
-				fmt.Println()
-				return fmt.Errorf("error: no command input and stdin is empty")
-			}
 			reader = bufio.NewReader(os.Stdin)
 		} else {
 			var builder strings.Builder

--- a/commands/run.go
+++ b/commands/run.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/ipfs/iptb/testbed"
 	"github.com/ipfs/iptb/testbed/interfaces"
-	"github.com/mattn/go-shellwords"
+	"github.com/gxed/go-shellwords"
 )
 
 var RunCmd = cli.Command{
@@ -53,6 +53,13 @@ var RunCmd = cli.Command{
 
 		var reader io.Reader
 		if c.IsSet("stdin") {
+			finfo, err := os.Stdin.Stat()
+			if err != nil {
+				return err
+			}
+			if finfo.Size() == 0 && finfo.Mode()&os.ModeNamedPipe == 0 {
+				return fmt.Errorf("error: no command input and stdin is empty")
+			}
 			reader = bufio.NewReader(os.Stdin)
 		} else {
 			var builder strings.Builder

--- a/commands/run.go
+++ b/commands/run.go
@@ -1,9 +1,13 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"path"
+	"regexp"
+	"strings"
 
 	cli "github.com/urfave/cli"
 
@@ -17,6 +21,10 @@ var RunCmd = cli.Command{
 	Usage:     "run command on specified nodes (or all)",
 	ArgsUsage: "[nodes] -- <command...>",
 	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "cmdFile",
+			Usage: "File containing list of commands to run asynchronously on nodes.",
+		},
 		cli.BoolFlag{
 			Name:   "terminator",
 			Hidden: true,
@@ -26,7 +34,6 @@ var RunCmd = cli.Command{
 		if present := isTerminatorPresent(c); present {
 			return c.Set("terminator", "true")
 		}
-
 		return nil
 	},
 	Action: func(c *cli.Context) error {
@@ -48,6 +55,57 @@ var RunCmd = cli.Command{
 		list, err := parseRange(nodeRange)
 		if err != nil {
 			return fmt.Errorf("could not parse node range %s", nodeRange)
+		}
+
+		if c.IsSet("cmdFile") {
+			cmdFile, err := os.Open(c.String("cmdFile"))
+			if err != nil {
+				return err
+			}
+			defer cmdFile.Close()
+
+			reg := regexp.MustCompile(`(?:(?P<nodeRange>.*?): *)(?P<cmd>[^\\z]+)`)
+			scanner := bufio.NewScanner(cmdFile)
+			line := 0
+			var ranges [][]int
+			var runCmds []outputFunc
+			for scanner.Scan() {
+				submatch := reg.FindStringSubmatch(scanner.Text())
+				if len(submatch) != 3 {
+					return fmt.Errorf("could not parse line %d of input file", line)
+				}
+				matches := make(map[string]string)
+				for i, name := range reg.SubexpNames() {
+					if i != 0 && name != "" {
+						matches[name] = submatch[i]
+					}
+				}
+
+				nodeRange := matches["nodeRange"]
+				if nodeRange == "" {
+					nodeRange = fmt.Sprintf("[0-%d]", len(nodes)-1)
+				}
+
+				list, err := parseRange(nodeRange)
+				if err != nil {
+					return fmt.Errorf("parse error on line %d: %s", line, err)
+				}
+				ranges = append(ranges, list)
+
+				tokens := strings.Fields(matches["cmd"])
+				runCmd := func(node testbedi.Core) (testbedi.Output, error) {
+					return node.RunCmd(context.Background(), nil, tokens...)
+				}
+				runCmds = append(runCmds, runCmd)
+
+				line++
+			}
+
+			results, err := mapListWithOutput(ranges, nodes, runCmds)
+			if err != nil {
+				return err
+			}
+			return buildReport(results)
 		}
 
 		runCmd := func(node testbedi.Core) (testbedi.Output, error) {

--- a/commands/run.go
+++ b/commands/run.go
@@ -20,20 +20,21 @@ var RunCmd = cli.Command{
 	Usage:     "run command on specified nodes (or all)",
 	ArgsUsage: "[nodes] -- <command...>",
 	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:  "cmdFile",
-			Usage: "File containing list of commands to run asynchronously on nodes.",
-		},
 		cli.BoolFlag{
 			Name:   "terminator",
 			Hidden: true,
 		},
+		cli.BoolFlag{
+			Name:   "stdin",
+			Hidden: true,
+		},
 	},
 	Before: func(c *cli.Context) error {
-		if !c.IsSet("cmdFile") {
-			if present := isTerminatorPresent(c); present {
-				return c.Set("terminator", "true")
-			}
+		if c.NArg() == 0 {
+			return c.Set("stdin", "true")
+		}
+		if present := isTerminatorPresent(c); present {
+			return c.Set("terminator", "true")
 		}
 		return nil
 	},
@@ -49,14 +50,8 @@ var RunCmd = cli.Command{
 
 		var args [][]string
 		var terminatorPresent []bool
-		if c.IsSet("cmdFile") {
-			cmdFile, err := os.Open(c.String("cmdFile"))
-			if err != nil {
-				return err
-			}
-			defer cmdFile.Close()
-
-			scanner := bufio.NewScanner(cmdFile)
+		if c.IsSet("stdin") {
+			scanner := bufio.NewScanner(os.Stdin)
 			for scanner.Scan() {
 				tokens := strings.Fields(scanner.Text())
 				term := tokens[0] == "--"

--- a/commands/run.go
+++ b/commands/run.go
@@ -12,9 +12,9 @@ import (
 
 	cli "github.com/urfave/cli"
 
+	"github.com/gxed/go-shellwords"
 	"github.com/ipfs/iptb/testbed"
 	"github.com/ipfs/iptb/testbed/interfaces"
-	"github.com/gxed/go-shellwords"
 )
 
 var RunCmd = cli.Command{
@@ -58,6 +58,8 @@ var RunCmd = cli.Command{
 				return err
 			}
 			if finfo.Size() == 0 && finfo.Mode()&os.ModeNamedPipe == 0 {
+				cli.ShowCommandHelp(c, "run")
+				fmt.Println()
 				return fmt.Errorf("error: no command input and stdin is empty")
 			}
 			reader = bufio.NewReader(os.Stdin)

--- a/commands/run.go
+++ b/commands/run.go
@@ -115,7 +115,7 @@ are printed.
 		for scanner.Scan() {
 			tokens, err := shellwords.Parse(scanner.Text())
 			if err != nil {
-				return fmt.Errorf("parser error on line %d: %s", line, err)
+				return fmt.Errorf("parse error on line %d: %s", line, err)
 			}
 			if strings.HasPrefix(tokens[0], "#") {
 				continue

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -63,6 +63,10 @@ func parseCommand(args []string, terminator bool) (string, []string) {
 		return args[0], []string{}
 	}
 
+	if args[0] == "--" {
+		return "", args[1:]
+	}
+
 	arguments := args[1:]
 
 	if arguments[0] == "--" {

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -147,7 +147,7 @@ func mapListWithOutput(ranges [][]int, nodes []testbedi.Core, fns []outputFunc) 
 
 	for i, list := range ranges {
 		wg.Add(1)
-		go func() {
+		go func(i int, list []int) {
 			defer wg.Done()
 			results_i, err := mapWithOutput(list, nodes, fns[i])
 
@@ -160,7 +160,7 @@ func mapListWithOutput(ranges [][]int, nodes []testbedi.Core, fns []outputFunc) 
 			for j, result := range results_i {
 				results[offsets[i]+j] = result
 			}
-		}()
+		}(i, list)
 		wg.Wait()
 	}
 

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -165,8 +165,6 @@ func mapListWithOutput(ranges [][]int, nodes []testbedi.Core, fns []outputFunc) 
 	}
 
 	if len(errs) != 0 {
-		// TODO: should shape of return error be same as results?
-		//       e.g. return []error instead of error
 		return results, cli.NewMultiError(errs...)
 	}
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
       "version": "0.0.1"
     },
     {
-      "author": "dgrisham",
-      "hash": "QmWnA5hxsXLWGSD2Wh16d1c4FPVcs4Qm4xwPiwsJdXgkFX",
+      "author": "mattn",
+      "hash": "QmbgMitQCJBeteUr9jGMyTRFjhZQjXKW5Kif6UdK4aW6W6",
       "name": "go-shellwords",
       "version": "0.0.0"
     }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
       "hash": "QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy",
       "name": "errors",
       "version": "0.0.1"
+    },
+    {
+      "author": "dgrisham",
+      "hash": "QmWnA5hxsXLWGSD2Wh16d1c4FPVcs4Qm4xwPiwsJdXgkFX",
+      "name": "go-shellwords",
+      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.6.0",

--- a/plugins/ipfs/Makefile
+++ b/plugins/ipfs/Makefile
@@ -3,16 +3,16 @@ all: ipfslocal ipfsdocker
 deps:
 	gx install
 
-ipfslocal:
-	# gx-go rw
+ipfslocal: deps
+	gx-go rw
 	(cd local; go build -buildmode=plugin -o ../../localipfs.so)
-	# gx-go uw
+	gx-go uw
 CLEAN += localipfs.so
 
-ipfsdocker:
-	# gx-go rw
+ipfsdocker: deps
+	gx-go rw
 	(cd docker; go build -buildmode=plugin -o ../../dockeripfs.so)
-	# gx-go uw
+	gx-go uw
 CLEAN += dockeripfs.so
 
 .PHONY: all ipfslocal ipfsdocker

--- a/plugins/ipfs/Makefile
+++ b/plugins/ipfs/Makefile
@@ -3,16 +3,16 @@ all: ipfslocal ipfsdocker
 deps:
 	gx install
 
-ipfslocal: deps
-	gx-go rw
+ipfslocal:
+	# gx-go rw
 	(cd local; go build -buildmode=plugin -o ../../localipfs.so)
-	gx-go uw
+	# gx-go uw
 CLEAN += localipfs.so
 
-ipfsdocker: deps
-	gx-go rw
+ipfsdocker:
+	# gx-go rw
 	(cd docker; go build -buildmode=plugin -o ../../dockeripfs.so)
-	gx-go uw
+	# gx-go uw
 CLEAN += dockeripfs.so
 
 .PHONY: all ipfslocal ipfsdocker


### PR DESCRIPTION
I have an application where I want to easily run commands asynchronously on nodes. While the new async update to `iptb run` is awesome and covers some of my use cases, there are others where I want to asynchronously run *different* commands on nodes. This adds that functionality.

Usage: Pass `--cmdFile <cmds>` to `iptb run`, where `<cmds>` is a file where each line is of the form `<nodeRange>: <cmd>` -- `<cmd>` is the command to run on all of the nodes in `<nodeRange>`. Each `<nodeRange>` should have the same format as that accepted by `commands.parseRange()`.

Example `<cmds>` file:

```
0: echo hi
[1-3]: echo bye
[4-5]: echo hello
```

It is not necessary that all nodes are account for, and nodes can also appear more than once. For example, if there are 3 nodes, we can do:

```
0: echo hi
[0,2]: echo bye
```

I'm curious what others' thoughts are on the utility of this feature, and the implementation.