### PR TITLE
Fix: Add `daemon` arg to `docker run` in dockeripfs plugin.

### DIFF
--- a/plugins/ipfs/docker/dockeripfs.go
+++ b/plugins/ipfs/docker/dockeripfs.go
@@ -184,6 +184,9 @@ func (l *DockerIpfs) Start(ctx context.Context, wait bool, args ...string) (test
 	}
 
 	fargs := []string{"run", "-d", "-v", l.dir + ":/data/ipfs", l.image}
+	if len(args) > 0 {
+		fargs = append(fargs, "daemon")
+	}
 	fargs = append(fargs, args...)
 	cmd := exec.Command("docker", fargs...)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
This PR adds `daemon` to the end of the `docker run` args whenever the user passes in `<ipfs-args>` to `iptb start -- <ipfs-args>`. Without this additional argument, the IPFS daemon logs a deprecation warning:

```
$ iptb auto --type dockeripfs --count 1
$ iptb start -- --enc=json
$ docker logs $(cat $IPTB_ROOT/testbeds/default/0/dockerid)
Changing user to ipfs
ipfs version 0.4.17
Found IPFS fs-repo at /data/ipfs
DEPRECATED: arguments have been set but the first argument isn't 'daemon'
DEPRECATED: run 'docker run ipfs/go-ipfs daemon --enc=json' instead
DEPRECATED: see the following PRs for more information:
DEPRECATED: * https://github.com/ipfs/go-ipfs/pull/3573
DEPRECATED: * https://github.com/ipfs/go-ipfs/pull/3685
Initializing daemon...
Swarm listening on /ip4/127.0.0.1/tcp/4001
Swarm listening on /ip4/172.17.0.73/tcp/4001
Swarm listening on /p2p-circuit/ipfs/QmeC2PYtwk5zygCKXpCBkdTS995FfCKK4wf6TjYSJP2UJx
Swarm announcing /ip4/127.0.0.1/tcp/4001
Swarm announcing /ip4/172.17.0.73/tcp/4001
API server listening on /ip4/0.0.0.0/tcp/5001
Daemon is ready
```

We don't pass `daemon` into `docker run` when the user hasn't provided additional args, because `docker run` has default args when nothing else is passed.

For more info, see the PRs listed in the log output:

-   https://github.com/ipfs/go-ipfs/pull/3573
-   https://github.com/ipfs/go-ipfs/pull/3685