### PR TITLE
Make cli a package

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+
+	cli "github.com/urfave/cli"
+
+	"github.com/ipfs/iptb/commands"
+	"github.com/ipfs/iptb/testbed"
+)
+
+func loadPlugins(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil
+	}
+
+	plugs, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range plugs {
+		plg, err := testbed.LoadPlugin(path.Join(dir, f.Name()))
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			continue
+		}
+
+		overloaded, err := testbed.RegisterPlugin(*plg, false)
+		if overloaded {
+			fmt.Fprintf(os.Stderr, "overriding built in plugin %s with %s\n", plg.PluginName, path.Join(dir, f.Name()))
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func NewCli() *cli.App {
+	app := cli.NewApp()
+	app.Usage = "iptb is a tool for managing test clusters of libp2p nodes"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "testbed",
+			Value:  "default",
+			EnvVar: "IPTB_TESTBED",
+			Usage:  "Name of testbed to use under IPTB_ROOT",
+		},
+		cli.StringFlag{
+			Name:   "IPTB_ROOT",
+			EnvVar: "IPTB_ROOT",
+			Hidden: true,
+		},
+	}
+	app.Before = func(c *cli.Context) error {
+		flagRoot := c.GlobalString("IPTB_ROOT")
+
+		if len(flagRoot) == 0 {
+			home := os.Getenv("HOME")
+			if len(home) == 0 {
+				return fmt.Errorf("environment variable HOME not set")
+			}
+
+			flagRoot = path.Join(home, "testbed")
+		} else {
+			var err error
+
+			flagRoot, err = filepath.Abs(flagRoot)
+			if err != nil {
+				return err
+			}
+		}
+
+		c.Set("IPTB_ROOT", flagRoot)
+
+		return loadPlugins(path.Join(flagRoot, "plugins"))
+	}
+	app.Commands = []cli.Command{
+		commands.AutoCmd,
+		commands.TestbedCmd,
+
+		commands.InitCmd,
+		commands.StartCmd,
+		commands.StopCmd,
+		commands.RestartCmd,
+		commands.RunCmd,
+		commands.ConnectCmd,
+		commands.ShellCmd,
+
+		commands.AttrCmd,
+
+		commands.LogsCmd,
+		commands.EventsCmd,
+		commands.MetricCmd,
+	}
+
+	// https://github.com/urfave/cli/issues/736
+	// Currently unreleased
+	/*
+		app.ExitErrHandler = func(c *cli.Context, err error) {
+			switch err.(type) {
+			case *commands.UsageError:
+				fmt.Fprintf(c.App.ErrWriter, "%s\n\n", err)
+				cli.ShowCommandHelpAndExit(c, c.Command.Name, 1)
+			default:
+				cli.HandleExitCoder(err)
+			}
+		}
+	*/
+
+	app.ErrWriter = os.Stderr
+	app.Writer = os.Stdout
+
+	return app
+}

--- a/main.go
+++ b/main.go
@@ -2,126 +2,16 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path"
-	"path/filepath"
 
-	cli "github.com/urfave/cli"
-
-	"github.com/ipfs/iptb/commands"
-	"github.com/ipfs/iptb/testbed"
+	"github.com/ipfs/iptb/cli"
 )
 
-func loadPlugins(dir string) error {
-	if _, err := os.Stat(dir); os.IsNotExist(err) {
-		return nil
-	}
-
-	plugs, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return err
-	}
-
-	for _, f := range plugs {
-		plg, err := testbed.LoadPlugin(path.Join(dir, f.Name()))
-
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			continue
-		}
-
-		overloaded, err := testbed.RegisterPlugin(*plg, false)
-		if overloaded {
-			fmt.Fprintf(os.Stderr, "overriding built in plugin %s with %s\n", plg.PluginName, path.Join(dir, f.Name()))
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func main() {
-	app := cli.NewApp()
-	app.Usage = "iptb is a tool for managing test clusters of libp2p nodes"
-	app.Flags = []cli.Flag{
-		cli.StringFlag{
-			Name:   "testbed",
-			Value:  "default",
-			EnvVar: "IPTB_TESTBED",
-			Usage:  "Name of testbed to use under IPTB_ROOT",
-		},
-		cli.StringFlag{
-			Name:   "IPTB_ROOT",
-			EnvVar: "IPTB_ROOT",
-			Hidden: true,
-		},
-	}
-	app.Before = func(c *cli.Context) error {
-		flagRoot := c.GlobalString("IPTB_ROOT")
+	cli := cli.NewCli()
 
-		if len(flagRoot) == 0 {
-			home := os.Getenv("HOME")
-			if len(home) == 0 {
-				return fmt.Errorf("environment variable HOME not set")
-			}
-
-			flagRoot = path.Join(home, "testbed")
-		} else {
-			var err error
-
-			flagRoot, err = filepath.Abs(flagRoot)
-			if err != nil {
-				return err
-			}
-		}
-
-		c.Set("IPTB_ROOT", flagRoot)
-
-		return loadPlugins(path.Join(flagRoot, "plugins"))
-	}
-	app.Commands = []cli.Command{
-		commands.AutoCmd,
-		commands.TestbedCmd,
-
-		commands.InitCmd,
-		commands.StartCmd,
-		commands.StopCmd,
-		commands.RestartCmd,
-		commands.RunCmd,
-		commands.ConnectCmd,
-		commands.ShellCmd,
-
-		commands.AttrCmd,
-
-		commands.LogsCmd,
-		commands.EventsCmd,
-		commands.MetricCmd,
-	}
-
-	// https://github.com/urfave/cli/issues/736
-	// Currently unreleased
-	/*
-		app.ExitErrHandler = func(c *cli.Context, err error) {
-			switch err.(type) {
-			case *commands.UsageError:
-				fmt.Fprintf(c.App.ErrWriter, "%s\n\n", err)
-				cli.ShowCommandHelpAndExit(c, c.Command.Name, 1)
-			default:
-				cli.HandleExitCoder(err)
-			}
-		}
-	*/
-
-	app.ErrWriter = os.Stderr
-	app.Writer = os.Stdout
-
-	err := app.Run(os.Args)
-	if err != nil {
-		fmt.Fprintf(app.ErrWriter, "%s\n", err)
+	if err := cli.Run(os.Args); err != nil {
+		fmt.Fprintf(cli.ErrWriter, "%s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Being able to build plugins directly into the binary and not having to deal with building and installing them makes using iptb simpler for testing in large projects that try to completely control their dependencies, such as the go-ipfs project.

These changes move a large part of the the cli bootstrapping into a package that can be included and quickly setup to build a program which implements the iptb cli. The smallest example can be view in the new `main.go`.

This enables a simple way to build iptb with a plugin compiled into the binary, without having to modify the source of iptb itself, or having to re-implement the main cli.

Here is an example of how you could use the new cli package to build a binary with the iptb cli and a built in plugin.

```go
package main

import (
	"fmt"
	"os"

	"github.com/ipfs/iptb/cli"
	"github.com/ipfs/iptb/testbed"

	plugin "example.com/project/iptb/plugin"
)

func init() {
	_, err := testbed.RegisterPlugin(testbed.IptbPlugin{
		From:        "<builtin>",
		NewNode:     plugin.NewNode,
		GetAttrList: plugin.GetAttrList,
		GetAttrDesc: plugin.GetAttrDesc,
		PluginName:  plugin.PluginName,
		BuiltIn:     true,
	}, false)

	if err != nil {
		panic(err)
	}
}

func main() {
	cli := cli.NewCli()
	if err := cli.Run(os.Args); err != nil {
		fmt.Fprintf(cli.ErrWriter, "%s\n", err)
		os.Exit(1)
	}
}
```
