### PR TITLE
Add container attribute to `dockeripfs` plugin to get container ID.

### DIFF
--- a/plugins/ipfs/docker/dockeripfs.go
+++ b/plugins/ipfs/docker/dockeripfs.go
@@ -30,7 +30,8 @@ var ErrTimeout = errors.New("timeout")
 var PluginName = "dockeripfs"
 
 const (
-	attrIfName = "ifname"
+	attrIfName    = "ifname"
+	attrContainer = "container"
 )
 
 type DockerIpfs struct {
@@ -113,13 +114,15 @@ func init() {
 	}
 
 	GetAttrList = func() []string {
-		return append(ipfs.GetAttrList(), attrIfName)
+		return append(ipfs.GetAttrList(), attrIfName, attrContainer)
 	}
 
 	GetAttrDesc = func(attr string) (string, error) {
 		switch attr {
 		case attrIfName:
 			return "docker ifname", nil
+		case attrContainer:
+			return "docker container id", nil
 		}
 
 		return ipfs.GetAttrDesc(attr)
@@ -421,6 +424,8 @@ func (l *DockerIpfs) Attr(attr string) (string, error) {
 	switch attr {
 	case attrIfName:
 		return l.getInterfaceName()
+	case attrContainer:
+		return l.getID()
 	}
 
 	return ipfs.GetAttr(l, attr)


### PR DESCRIPTION
```
$ iptb attr list 0
        id: node ID
        path: node IPFS_PATH
        ifname: docker ifname
        container: docker container id
$ iptb attr get 0 container
30a2644d44b22f636f2e03948023a5b0c2225746b8db5c9987ecdf477602e36a  
```