### PR TITLE
Fix: dockeripfs plugin now respects `wait` flag for `ipfs start`.

### DIFF
--- a/plugins/ipfs/docker/dockeripfs.go
+++ b/plugins/ipfs/docker/dockeripfs.go
@@ -211,6 +211,10 @@ func (l *DockerIpfs) Start(ctx context.Context, wait bool, args ...string) (test
 		return nil, err
 	}
 
+	if wait {
+		return nil, ipfs.WaitOnAPI(l)
+	}
+
 	return nil, nil
 }
 


### PR DESCRIPTION
Fixes @travisperson's comment made [here](https://github.com/ipfs/iptb/issues/86#issuecomment-420835005).