### PR TITLE
Add quiet flag to suppress iptb output

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -54,6 +54,10 @@ func NewCli() *cli.App {
 			EnvVar: "IPTB_TESTBED",
 			Usage:  "Name of testbed to use under IPTB_ROOT",
 		},
+		cli.BoolFlag{
+			Name:  "quiet",
+			Usage: "Suppresses extra output from iptb",
+		},
 		cli.StringFlag{
 			Name:   "IPTB_ROOT",
 			EnvVar: "IPTB_ROOT",

--- a/commands/auto.go
+++ b/commands/auto.go
@@ -50,6 +50,7 @@ $ iptb auto           -count 5 -type <type>
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagQuiet := c.GlobalBool("quiet")
 		flagType := c.String("type")
 		flagStart := c.Bool("start")
 		flagCount := c.Int("count")
@@ -89,7 +90,7 @@ $ iptb auto           -count 5 -type <type>
 			return err
 		}
 
-		if err := buildReport(results); err != nil {
+		if err := buildReport(results, flagQuiet); err != nil {
 			return err
 		}
 
@@ -103,7 +104,7 @@ $ iptb auto           -count 5 -type <type>
 				return err
 			}
 
-			if err := buildReport(results); err != nil {
+			if err := buildReport(results, flagQuiet); err != nil {
 				return err
 			}
 		}

--- a/commands/init.go
+++ b/commands/init.go
@@ -32,6 +32,7 @@ var InitCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagQuiet := c.GlobalBool("quiet")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -59,6 +60,6 @@ var InitCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, flagQuiet)
 	},
 }

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -31,6 +31,7 @@ var LogsCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagQuiet := c.GlobalBool("quiet")
 		flagErr := c.BoolT("err")
 		flagOut := c.BoolT("out")
 
@@ -84,7 +85,7 @@ var LogsCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, flagQuiet)
 	},
 }
 

--- a/commands/restart.go
+++ b/commands/restart.go
@@ -36,6 +36,7 @@ var RestartCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagQuiet := c.GlobalBool("quiet")
 		flagWait := c.Bool("wait")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
@@ -68,6 +69,6 @@ var RestartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, flagQuiet)
 	},
 }

--- a/commands/run.go
+++ b/commands/run.go
@@ -85,6 +85,7 @@ are printed.
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagQuiet := c.GlobalBool("quiet")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -144,6 +145,6 @@ are printed.
 		}
 
 		results, err := mapListWithOutput(ranges, nodes, runCmds)
-		return buildReport(results)
+		return buildReport(results, flagQuiet)
 	},
 }

--- a/commands/start.go
+++ b/commands/start.go
@@ -36,6 +36,7 @@ var StartCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagQuiet := c.GlobalBool("quiet")
 		flagWait := c.Bool("wait")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
@@ -64,6 +65,6 @@ var StartCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, flagQuiet)
 	},
 }

--- a/commands/stop.go
+++ b/commands/stop.go
@@ -19,6 +19,7 @@ var StopCmd = cli.Command{
 	Action: func(c *cli.Context) error {
 		flagRoot := c.GlobalString("IPTB_ROOT")
 		flagTestbed := c.GlobalString("testbed")
+		flagQuiet := c.GlobalBool("quiet")
 
 		tb := testbed.NewTestbed(path.Join(flagRoot, "testbeds", flagTestbed))
 		nodes, err := tb.Nodes()
@@ -46,6 +47,6 @@ var StopCmd = cli.Command{
 			return err
 		}
 
-		return buildReport(results)
+		return buildReport(results, flagQuiet)
 	},
 }

--- a/commands/utils.go
+++ b/commands/utils.go
@@ -218,12 +218,18 @@ func validRange(list []int, total int) error {
 	return nil
 }
 
-func buildReport(results []Result) error {
+func buildReport(results []Result, quiet bool) error {
 	var errs []error
 
 	for _, rs := range results {
 		if rs.Error != nil {
 			errs = append(errs, rs.Error)
+		}
+
+		if quiet {
+			io.Copy(os.Stdout, rs.Output.Stdout())
+			io.Copy(os.Stdout, rs.Output.Stderr())
+			continue
 		}
 
 		if rs.Output != nil {


### PR DESCRIPTION
This makes it easier to get raw output, mostly helpful when dealing with commands run over a single node.