### PR TITLE
util: cleanup the yes-no-prompt

### DIFF
--- a/testbed/testbed.go
+++ b/testbed/testbed.go
@@ -58,7 +58,7 @@ func (tb BasicTestbed) Name() string {
 
 func AlreadyInitCheck(dir string, force bool) error {
 	if _, err := os.Stat(filepath.Join(dir, "nodespec.json")); !os.IsNotExist(err) {
-		if !force && !iptbutil.YesNoPrompt("testbed nodes already exist, overwrite? [y/n]") {
+		if !force && !iptbutil.YesNoPrompt("testbed nodes already exist, overwrite?") {
 			return nil
 		}
 

--- a/util/util.go
+++ b/util/util.go
@@ -7,7 +7,7 @@ import (
 func YesNoPrompt(prompt string) bool {
 	var s string
 	for {
-		fmt.Println(prompt)
+		fmt.Printf("%s [y/n] ", prompt)
 		fmt.Scanf("%s", &s)
 		switch s {
 		case "y", "Y":


### PR DESCRIPTION
1. Don't print a newline before the response.
2. Auto-add the `[y/n]` text.